### PR TITLE
feat: Add JEPA state decoder and skip training options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -145,3 +145,18 @@ early_stopping:
   checkpoint_path_enc_dec: "best_encoder_decoder.pth"
   checkpoint_path_jepa: "best_jepa.pth"
   validation_split: 0.2 # Proportion of data to use for validation
+
+jepa_decoder_training:
+  enabled: false # Set to true to enable training this decoder
+  num_epochs: 50
+  learning_rate: 0.0003
+  checkpoint_path: "best_jepa_decoder.pth"
+  # Add early stopping parameters similar to the main ones if desired
+  early_stopping:
+    patience: 10
+    delta: 0.001
+    metric: "val_loss_jepa_decoder" # Example metric
+
+training_options: # New section name, as 'training_configuration' is too generic
+  skip_std_enc_dec_training_if_loaded: false
+  skip_jepa_training_if_loaded: false

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from src.training_engine import run_training_epochs
 
 def main():
     # 1. Load Configuration
-    # config.yaml is expected to be in the same directory as this main.py (project root)
     config = load_config(config_path='config.yaml')
 
     # 2. Setup Device
@@ -22,7 +21,6 @@ def main():
     )
     print(f"Using device: {device}")
 
-    # Create dataset and model directories early
     model_dir = config.get('model_dir', 'trained_models/')
     dataset_dir = config.get('dataset_dir', 'datasets/')
     os.makedirs(model_dir, exist_ok=True)
@@ -34,7 +32,6 @@ def main():
     action_dim, action_type, observation_space = get_env_details(config['environment_name'])
 
     # 4. Prepare Dataloaders
-    # Validation split ratio from early stopping config or general data config
     early_stopping_config = config.get('early_stopping', {})
     validation_split = early_stopping_config.get('validation_split', 0.2)
     dataloaders_map = {}
@@ -51,106 +48,121 @@ def main():
     input_channels = config.get('input_channels', 3)
     models_map = initialize_models(config, action_dim, device, image_h_w, input_channels)
 
-    # --- Model Loading Logic (Part 2) ---
+    # --- Model Loading Logic ---
     load_model_path = config.get('load_model_path', '')
-    model_type_to_load = config.get('model_type_to_load', 'std_enc_dec')
-    # model_dir is already available from directory creation step above
+    model_type_to_load = config.get('model_type_to_load', 'std_enc_dec') # e.g., 'std_enc_dec', 'jepa'
+
+    std_enc_dec_loaded_successfully = False
+    jepa_model_loaded_successfully = False
 
     if load_model_path:
         full_model_load_path = os.path.join(model_dir, load_model_path)
         if os.path.exists(full_model_load_path):
             print(f"Attempting to load pre-trained model from: {full_model_load_path}")
-            loaded_successfully = False
-            if model_type_to_load == 'std_enc_dec' and models_map.get('std_enc_dec'):
-                models_map['std_enc_dec'].load_state_dict(torch.load(full_model_load_path, map_location=device))
-                print(f"Loaded Standard Encoder/Decoder model from {full_model_load_path}")
-                loaded_successfully = True
-            elif model_type_to_load == 'jepa' and models_map.get('jepa'):
-                models_map['jepa'].load_state_dict(torch.load(full_model_load_path, map_location=device))
-                print(f"Loaded JEPA model from {full_model_load_path}")
-                loaded_successfully = True
-            # Add other model types here if needed, e.g., for reward MLPs if they are saved/loaded independently
-
-            if not loaded_successfully:
-                print(f"Warning: Model type '{model_type_to_load}' specified for loading, but not found in configured models_map or not supported by current loading logic.")
+            try:
+                if model_type_to_load == 'std_enc_dec' and models_map.get('std_enc_dec'):
+                    models_map['std_enc_dec'].load_state_dict(torch.load(full_model_load_path, map_location=device))
+                    print(f"Loaded Standard Encoder/Decoder model from {full_model_load_path}")
+                    std_enc_dec_loaded_successfully = True
+                elif model_type_to_load == 'jepa' and models_map.get('jepa'):
+                    models_map['jepa'].load_state_dict(torch.load(full_model_load_path, map_location=device))
+                    print(f"Loaded JEPA model from {full_model_load_path}")
+                    jepa_model_loaded_successfully = True
+                # Add other model types here if they can be loaded independently via 'load_model_path'
+                else:
+                    print(f"Warning: Model type '{model_type_to_load}' specified for loading, but it's either not configured or not supported by this loading block.")
+            except Exception as e:
+                print(f"Error loading model {model_type_to_load} from {full_model_load_path}: {e}. Proceeding with default initialization for this model.")
         else:
-            print(f"Warning: Specified model path '{full_model_load_path}' not found. Proceeding with default initialization.")
+            print(f"Warning: Specified model path '{full_model_load_path}' not found. Proceeding with default initialization(s).")
     else:
         print("No pre-trained model path specified in 'load_model_path'. Models will be initialized from scratch or use their default initialization.")
     # --- End of Model Loading Logic ---
 
-    # Extract models for convenience if needed, or just pass models_map
     std_enc_dec = models_map.get('std_enc_dec')
     jepa_model = models_map.get('jepa')
-    # reward_mlp_enc_dec = models_map.get('reward_mlp_enc_dec') # available in map
-    # reward_mlp_jepa = models_map.get('reward_mlp_jepa')       # available in map
 
-    # 6. Initialize Loss Functions
-    # Pass jepa_model.latent_dim if DINO loss is configured
     jepa_model_latent_dim_for_dino = None
     if jepa_model and config.get('auxiliary_loss', {}).get('type') == 'dino':
-        jepa_model_latent_dim_for_dino = jepa_model.latent_dim # Accessing from initialized model
+        jepa_model_latent_dim_for_dino = jepa_model.latent_dim
 
     losses_map = initialize_loss_functions(config, device, jepa_model_latent_dim=jepa_model_latent_dim_for_dino)
-
-    # 7. Initialize Optimizers
     optimizers_map = initialize_optimizers(models_map, config)
 
     # 8. Run Training Epochs
-    # The training engine will handle early stopping and saving best models internally
-    run_training_epochs(
+    training_results = run_training_epochs( # Store results
         models_map=models_map,
         optimizers_map=optimizers_map,
         losses_map=losses_map,
         dataloaders_map=dataloaders_map,
         device=device,
-        config=config, # Pass the full config for various parameters like num_epochs, log_interval etc.
+        config=config,
         action_dim=action_dim,
         action_type=action_type,
-        image_h_w=image_h_w, # Needed for reward MLP input calculation within training_engine
-        input_channels=input_channels # Needed for reward MLP input calculation
+        image_h_w=image_h_w,
+        input_channels=input_channels,
+        std_enc_dec_loaded_successfully=std_enc_dec_loaded_successfully, # Pass flag
+        jepa_loaded_successfully=jepa_model_loaded_successfully          # Pass flag
     )
 
     # 9. Post-Training: Load best models and set to eval mode
     # Checkpoint paths from config (used by training_engine for saving, here for loading)
-    # model_dir is available from the beginning of main()
-    best_checkpoint_filename_enc_dec = early_stopping_config.get('checkpoint_path_enc_dec', 'best_encoder_decoder.pth')
-    best_checkpoint_filename_jepa = early_stopping_config.get('checkpoint_path_jepa', 'best_jepa.pth')
+    # model_dir is available. training_results contains paths to best models saved by engine.
 
-    full_checkpoint_path_enc_dec = os.path.join(model_dir, best_checkpoint_filename_enc_dec)
-    full_checkpoint_path_jepa = os.path.join(model_dir, best_checkpoint_filename_jepa)
+    print("\nLoading best models (if available) after training and setting to eval mode...")
 
-    print("Loading best models (if available) after training...")
-    if std_enc_dec and os.path.exists(full_checkpoint_path_enc_dec):
-        print(f"Loading best Encoder/Decoder model from {full_checkpoint_path_enc_dec}")
-        std_enc_dec.load_state_dict(torch.load(full_checkpoint_path_enc_dec, map_location=device))
-    elif std_enc_dec:
-        print(f"No checkpoint found for Encoder/Decoder at {full_checkpoint_path_enc_dec}. Model remains in its last training state.")
-
-    # Ensure model is in eval mode even if no checkpoint was loaded
-    if std_enc_dec:
+    # Standard Encoder/Decoder
+    if std_enc_dec: # Check if model was initialized
+        best_checkpoint_enc_dec_path = training_results.get("best_checkpoint_enc_dec")
+        if best_checkpoint_enc_dec_path and os.path.exists(best_checkpoint_enc_dec_path):
+            print(f"Loading best Encoder/Decoder model from {best_checkpoint_enc_dec_path}")
+            std_enc_dec.load_state_dict(torch.load(best_checkpoint_enc_dec_path, map_location=device))
+        elif not std_enc_dec_loaded_successfully: # Only print if not initially loaded
+             print(f"No best checkpoint found for Encoder/Decoder at expected path. Model remains in its last training state.")
         std_enc_dec.eval()
 
-    if jepa_model and os.path.exists(full_checkpoint_path_jepa):
-        print(f"Loading best JEPA model from {full_checkpoint_path_jepa}")
-        jepa_model.load_state_dict(torch.load(full_checkpoint_path_jepa, map_location=device))
-    elif jepa_model:
-        print(f"No checkpoint found for JEPA at {full_checkpoint_path_jepa}. Model remains in its last training state.")
-
-    if jepa_model:
+    # JEPA Model
+    if jepa_model: # Check if model was initialized
+        best_checkpoint_jepa_path = training_results.get("best_checkpoint_jepa")
+        if best_checkpoint_jepa_path and os.path.exists(best_checkpoint_jepa_path):
+            print(f"Loading best JEPA model from {best_checkpoint_jepa_path}")
+            jepa_model.load_state_dict(torch.load(best_checkpoint_jepa_path, map_location=device))
+        elif not jepa_model_loaded_successfully: # Only print if not initially loaded
+            print(f"No best checkpoint found for JEPA at expected path. Model remains in its last training state.")
         jepa_model.eval()
 
-    # Also set reward MLPs to eval mode if they exist
+    # JEPA State Decoder
+    jepa_decoder = models_map.get('jepa_decoder')
+    jepa_decoder_training_config = config.get('jepa_decoder_training', {})
+    if jepa_decoder and jepa_decoder_training_config.get('enabled', False):
+        # Path to best decoder model is now returned by run_training_epochs
+        best_checkpoint_jepa_decoder_path = training_results.get("best_checkpoint_jepa_decoder")
+        print(f"Attempting to load best JEPA State Decoder (if available) after training...")
+        if best_checkpoint_jepa_decoder_path and os.path.exists(best_checkpoint_jepa_decoder_path):
+            print(f"Loading best JEPA State Decoder model from {best_checkpoint_jepa_decoder_path}")
+            jepa_decoder.load_state_dict(torch.load(best_checkpoint_jepa_decoder_path, map_location=device))
+        else:
+            # This message is important if decoder training was enabled but no checkpoint was saved/found
+            print(f"No best checkpoint found for JEPA State Decoder at expected path. Model remains in its last training state (if any training occurred).")
+        jepa_decoder.eval()
+    elif jepa_decoder : # Decoder exists but was not enabled for training
+        print("JEPA State Decoder was initialized but not enabled for training. Setting to eval mode.")
+        jepa_decoder.eval()
+
+
+    # Reward MLPs
     if models_map.get('reward_mlp_enc_dec'):
         models_map['reward_mlp_enc_dec'].eval()
+        print("Encoder-Decoder Reward MLP set to eval mode.")
     if models_map.get('reward_mlp_jepa'):
         models_map['reward_mlp_jepa'].eval()
+        print("JEPA Reward MLP set to eval mode.")
 
-    # Set auxiliary loss function to eval mode if applicable (e.g., DINO's center update)
     if losses_map.get('aux_fn') and hasattr(losses_map['aux_fn'], 'eval'):
         losses_map['aux_fn'].eval()
+        print("Auxiliary loss function (if DINO) set to eval mode.")
 
-    print("Process complete. Models are in eval mode (with best weights loaded if checkpoints were found).")
+    print("\nProcess complete. Relevant models are in eval mode.")
 
 if __name__ == '__main__':
     main()

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,12 +3,14 @@ from .vit import ViT
 from .encoder_decoder import StandardEncoderDecoder
 from .jepa import JEPA
 from .cnn import CNNEncoder
-from .mlp import MLPEncoder  # Add this line
+from .mlp import MLPEncoder
+from .jepa_state_decoder import JEPAStateDecoder # Added line
 
 __all__ = [
     "ViT",
     "StandardEncoderDecoder",
     "JEPA",
     "CNNEncoder",
-    "MLPEncoder"  # Add this line
+    "MLPEncoder",
+    "JEPAStateDecoder" # Added line
 ]

--- a/src/models/jepa_state_decoder.py
+++ b/src/models/jepa_state_decoder.py
@@ -1,0 +1,169 @@
+import torch
+import torch.nn as nn
+from einops.layers.torch import Rearrange
+
+class JEPAStateDecoder(nn.Module):
+    def __init__(self,
+                 input_latent_dim: int,
+                 decoder_dim: int,
+                 decoder_depth: int,
+                 decoder_heads: int,
+                 decoder_mlp_dim: int,
+                 output_channels: int,
+                 output_image_size: tuple[int, int], # (height, width)
+                 decoder_dropout: float = 0.0,
+                 decoder_patch_size: int = 8):
+        super().__init__()
+
+        self.output_channels = output_channels
+        self.output_image_h, self.output_image_w = output_image_size
+        self.decoder_patch_size = decoder_patch_size
+
+        if self.output_image_h % decoder_patch_size != 0 or self.output_image_w % decoder_patch_size != 0:
+            raise ValueError("Output image dimensions must be divisible by the decoder patch size.")
+
+        self.output_num_patches_h = self.output_image_h // decoder_patch_size
+        self.output_num_patches_w = self.output_image_w // decoder_patch_size
+        self.num_output_patches = self.output_num_patches_h * self.output_num_patches_w
+
+        output_patch_dim = output_channels * decoder_patch_size * decoder_patch_size
+
+        # Project the JEPA predictor's output to decoder dimension
+        self.decoder_input_projection = nn.Linear(input_latent_dim, decoder_dim)
+
+        # Transformer Decoder
+        decoder_layer = nn.TransformerDecoderLayer(
+            d_model=decoder_dim,
+            nhead=decoder_heads,
+            dim_feedforward=decoder_mlp_dim,
+            dropout=decoder_dropout,
+            batch_first=True # Important: batch dimension first
+        )
+        self.transformer_decoder = nn.TransformerDecoder(
+            decoder_layer=decoder_layer,
+            num_layers=decoder_depth
+        )
+
+        # Learnable query tokens for the decoder (one set of queries for all patches)
+        self.decoder_query_tokens = nn.Parameter(torch.randn(1, self.num_output_patches, decoder_dim))
+
+        # Map decoder output to pixel values for each patch
+        self.to_pixels = nn.Linear(decoder_dim, output_patch_dim)
+
+        # Rearrange patches back into an image
+        self.patch_to_image = Rearrange(
+            'b (h w) (p1 p2 c) -> b c (h p1) (w p2)',
+            p1=decoder_patch_size, p2=decoder_patch_size,
+            h=self.output_num_patches_h, w=self.output_num_patches_w,
+            c=output_channels
+        )
+
+    def forward(self, jepa_predictor_embedding: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the JEPA State Decoder.
+        Args:
+            jepa_predictor_embedding: Tensor of shape (b, input_latent_dim) from JEPA's predictor.
+        Returns:
+            predicted_next_state_image: Tensor of shape (b, output_channels, output_image_h, output_image_w).
+        """
+        batch_size = jepa_predictor_embedding.shape[0]
+
+        # 1. Project predictor embedding to decoder dimension to serve as memory
+        # Shape: (b, input_latent_dim) -> (b, decoder_dim)
+        decoder_memory = self.decoder_input_projection(jepa_predictor_embedding)
+        # Unsqueeze to make it (b, 1, decoder_dim) to act as a single memory item for the transformer
+        decoder_memory = decoder_memory.unsqueeze(1)
+
+        # 2. Prepare query tokens for the decoder
+        # Repeat query tokens for the batch size: (1, num_output_patches, decoder_dim) -> (b, num_output_patches, decoder_dim)
+        query_tokens = self.decoder_query_tokens.repeat(batch_size, 1, 1)
+
+        # 3. Pass through Transformer Decoder
+        # query_tokens (tgt): (b, num_output_patches, decoder_dim)
+        # decoder_memory (memory): (b, 1, decoder_dim)
+        # Output shape: (b, num_output_patches, decoder_dim)
+        decoded_representation = self.transformer_decoder(tgt=query_tokens, memory=decoder_memory)
+
+        # 4. Map to pixel values
+        # Shape: (b, num_output_patches, decoder_dim) -> (b, num_output_patches, output_patch_dim)
+        pixel_patches = self.to_pixels(decoded_representation)
+
+        # 5. Reshape patches to image
+        # Shape: (b, num_output_patches, output_patch_dim) -> (b, output_channels, output_image_h, output_image_w)
+        predicted_next_state_image = self.patch_to_image(pixel_patches)
+
+        return predicted_next_state_image
+
+if __name__ == '__main__':
+    # Example Usage (for testing the decoder directly)
+    batch_size_test = 4
+    latent_dim_test = 256 # Example latent dim from JEPA predictor
+    decoder_dim_test = 128
+    decoder_depth_test = 3
+    decoder_heads_test = 4
+    decoder_mlp_dim_test = 512
+    output_channels_test = 3
+    image_size_test = (64, 64)
+    patch_size_test = 8
+
+    # Instantiate the decoder
+    jepa_decoder = JEPAStateDecoder(
+        input_latent_dim=latent_dim_test,
+        decoder_dim=decoder_dim_test,
+        decoder_depth=decoder_depth_test,
+        decoder_heads=decoder_heads_test,
+        decoder_mlp_dim=decoder_mlp_dim_test,
+        output_channels=output_channels_test,
+        output_image_size=image_size_test,
+        decoder_patch_size=patch_size_test
+    )
+
+    # Create a dummy input tensor (simulating output from JEPA predictor)
+    dummy_predictor_output = torch.randn(batch_size_test, latent_dim_test)
+
+    # Get the predicted next state image
+    predicted_image = jepa_decoder(dummy_predictor_output)
+
+    print("JEPA State Decoder initialized.")
+    print(f"Input predictor embedding shape: {dummy_predictor_output.shape}")
+    print(f"Output predicted image shape: {predicted_image.shape}")
+
+    # Expected output shape: (batch_size_test, output_channels_test, image_size_test[0], image_size_test[1])
+    assert predicted_image.shape == (batch_size_test, output_channels_test, image_size_test[0], image_size_test[1])
+    print("Test passed: Output shape is correct.")
+
+    # Test with non-square image
+    image_size_test_rect = (48, 64)
+    patch_size_test_rect = 8
+    jepa_decoder_rect = JEPAStateDecoder(
+        input_latent_dim=latent_dim_test,
+        decoder_dim=decoder_dim_test,
+        decoder_depth=decoder_depth_test,
+        decoder_heads=decoder_heads_test,
+        decoder_mlp_dim=decoder_mlp_dim_test,
+        output_channels=output_channels_test,
+        output_image_size=image_size_test_rect,
+        decoder_patch_size=patch_size_test_rect
+    )
+    dummy_predictor_output_rect = torch.randn(batch_size_test, latent_dim_test)
+    predicted_image_rect = jepa_decoder_rect(dummy_predictor_output_rect)
+    print(f"Output predicted image shape (rectangular): {predicted_image_rect.shape}")
+    assert predicted_image_rect.shape == (batch_size_test, output_channels_test, image_size_test_rect[0], image_size_test_rect[1])
+    print("Test passed: Rectangular output shape is correct.")
+
+    # Test invalid patch size
+    try:
+        JEPAStateDecoder(
+            input_latent_dim=latent_dim_test,
+            decoder_dim=decoder_dim_test,
+            decoder_depth=decoder_depth_test,
+            decoder_heads=decoder_heads_test,
+            decoder_mlp_dim=decoder_mlp_dim_test,
+            output_channels=output_channels_test,
+            output_image_size=(64, 60), # 60 is not divisible by 8
+            decoder_patch_size=patch_size_test
+        )
+    except ValueError as e:
+        print(f"Caught expected error for invalid patch size: {e}")
+
+    print("JEPAStateDecoder basic tests completed.")

--- a/src/training_engine.py
+++ b/src/training_engine.py
@@ -5,7 +5,7 @@ import os # For os.path.exists in early stopping save/load
 
 # Note: Loss functions (mse_loss_fn, aux_loss_fn, aux_loss_name, aux_loss_weight)
 # will be passed in via the 'losses_map' dictionary.
-# Models (std_enc_dec, jepa_model, reward_mlp_enc_dec, reward_mlp_jepa) via 'models_map'.
+# Models (std_enc_dec, jepa_model, reward_mlp_enc_dec, reward_mlp_jepa, jepa_decoder) via 'models_map'.
 # Optimizers (optimizer_std_enc_dec, etc.) via 'optimizers_map'.
 # Dataloaders (train_dataloader, val_dataloader) via 'dataloaders_map'.
 # Configs (early_stopping_config, enc_dec_mlp_config, jepa_mlp_config, main_config for num_epochs, log_interval) via 'config'.
@@ -14,18 +14,22 @@ import os # For os.path.exists in early stopping save/load
 def run_training_epochs(
     models_map, optimizers_map, losses_map, dataloaders_map,
     device, config, action_dim, action_type,
-    image_h_w, input_channels # For reward MLP input calculation if needed
+    image_h_w, input_channels, # For reward MLP input calculation if needed
+    std_enc_dec_loaded_successfully=False, # New argument
+    jepa_loaded_successfully=False         # New argument
 ):
-    # Unpack from maps/config for convenience, matching original variable names closely
+    # Unpack from maps/config for convenience
     std_enc_dec = models_map.get('std_enc_dec')
     jepa_model = models_map.get('jepa')
     reward_mlp_enc_dec = models_map.get('reward_mlp_enc_dec')
     reward_mlp_jepa = models_map.get('reward_mlp_jepa')
+    jepa_decoder = models_map.get('jepa_decoder') # New model
 
     optimizer_std_enc_dec = optimizers_map.get('std_enc_dec')
     optimizer_jepa = optimizers_map.get('jepa')
     optimizer_reward_mlp_enc_dec = optimizers_map.get('reward_mlp_enc_dec')
     optimizer_reward_mlp_jepa = optimizers_map.get('reward_mlp_jepa')
+    optimizer_jepa_decoder = optimizers_map.get('jepa_decoder') # New optimizer
 
     mse_loss_fn = losses_map['mse']
     aux_loss_fn = losses_map.get('aux_fn')
@@ -33,55 +37,73 @@ def run_training_epochs(
     aux_loss_weight = losses_map.get('aux_weight', 0.0)
 
     train_dataloader = dataloaders_map['train']
-    val_dataloader = dataloaders_map.get('val') # val_dataloader can be None
+    val_dataloader = dataloaders_map.get('val')
 
     # Configs
     early_stopping_config = config.get('early_stopping', {})
-    model_dir = config.get('model_dir', 'trained_models/') # Read model_dir
+    model_dir = config.get('model_dir', 'trained_models/')
     patience = early_stopping_config.get('patience', 10)
     delta = early_stopping_config.get('delta', 0.001)
-    # Prepend model_dir to checkpoint paths
     checkpoint_path_enc_dec = os.path.join(model_dir, early_stopping_config.get('checkpoint_path_enc_dec', 'best_encoder_decoder.pth'))
     checkpoint_path_jepa = os.path.join(model_dir, early_stopping_config.get('checkpoint_path_jepa', 'best_jepa.pth'))
-    # validation_split is used to decide if validation runs, passed implicitly by val_dataloader's existence
 
     enc_dec_mlp_config = config.get('reward_predictors', {}).get('encoder_decoder_reward_mlp', {})
     jepa_mlp_config = config.get('reward_predictors', {}).get('jepa_reward_mlp', {})
 
     num_epochs = config.get('num_epochs', 10)
-    log_interval = config.get('log_interval', 50)
+    log_interval = config.get('log_interval', 50) # General log interval
 
-    print(f"Starting training for {num_epochs} epochs...")
+    print(f"Starting training, main models for {num_epochs} epochs...")
 
     # Early Stopping Trackers
     best_val_loss_enc_dec = float('inf')
     epochs_no_improve_enc_dec = 0
     best_val_loss_jepa = float('inf')
     epochs_no_improve_jepa = 0
-    early_stop_enc_dec = False if std_enc_dec and optimizer_std_enc_dec else True # If model or optimizer is None, it's "stopped"
-    early_stop_jepa = False if jepa_model and optimizer_jepa else True # If model or optimizer is None, it's "stopped"
+
+    # Initialize early_stop flags: if model or optimizer is None, it's effectively "stopped" or disabled.
+    early_stop_enc_dec = not (std_enc_dec and optimizer_std_enc_dec)
+    early_stop_jepa = not (jepa_model and optimizer_jepa)
+
+    # Handle Skip Training Flags based on loaded models
+    training_options = config.get('training_options', {})
+    skip_std_enc_dec_opt = training_options.get('skip_std_enc_dec_training_if_loaded', False)
+    skip_jepa_opt = training_options.get('skip_jepa_training_if_loaded', False)
+
+    if std_enc_dec_loaded_successfully and skip_std_enc_dec_opt and not early_stop_enc_dec:
+        early_stop_enc_dec = True
+        print("Standard Encoder/Decoder training will be skipped as a pre-trained model was loaded and skip option is enabled.")
+
+    if jepa_loaded_successfully and skip_jepa_opt and not early_stop_jepa:
+        early_stop_jepa = True
+        print("JEPA model training will be skipped as a pre-trained model was loaded and skip option is enabled.")
 
 
     for epoch in range(num_epochs):
         epoch_loss_std = 0
         epoch_loss_jepa_pred = 0
-        epoch_loss_jepa_aux = 0 # Raw aux loss
+        epoch_loss_jepa_aux = 0
         epoch_loss_reward_enc_dec = 0
         epoch_loss_reward_jepa = 0
 
         num_train_batches = len(train_dataloader) if train_dataloader else 0
         if num_train_batches == 0:
-            print(f"Epoch {epoch+1} has no training data. Skipping.")
-            continue
+            print(f"Epoch {epoch+1} has no training data for main models. Skipping.")
+            # Still need to check for JEPA decoder training later if it's enabled.
+            # If both main models are skipped, this loop might be short.
+            if early_stop_enc_dec and early_stop_jepa:
+                 print("Both main models already early stopped or skipped. Checking JEPA Decoder.")
+                 break # Break from main model epoch loop, then JEPA decoder loop will run.
+            # continue # Continue if one of them might still train
 
         # Main model training loop
         if std_enc_dec and not early_stop_enc_dec: std_enc_dec.train()
         if jepa_model and not early_stop_jepa: jepa_model.train()
-        if aux_loss_fn and hasattr(aux_loss_fn, 'train'): # For DINO Loss
+        if aux_loss_fn and hasattr(aux_loss_fn, 'train'):
             aux_loss_fn.train()
 
         # === Training Phase ===
-        if not (early_stop_enc_dec and early_stop_jepa): # Only loop if at least one model needs training
+        if not (early_stop_enc_dec and early_stop_jepa):
             for batch_idx, (s_t, a_t, r_t, s_t_plus_1) in enumerate(train_dataloader):
                 s_t, r_t, s_t_plus_1 = s_t.to(device), r_t.to(device).float().unsqueeze(1), s_t_plus_1.to(device)
 
@@ -91,8 +113,7 @@ def run_training_epochs(
                 else:
                     a_t_processed = a_t.float().to(device)
 
-                # Standard Encoder-Decoder Training
-                loss_std_item = 0 # for logging
+                loss_std_item = 0
                 if std_enc_dec and not early_stop_enc_dec:
                     optimizer_std_enc_dec.zero_grad()
                     predicted_s_t_plus_1 = std_enc_dec(s_t, a_t_processed)
@@ -102,10 +123,9 @@ def run_training_epochs(
                     loss_std_item = loss_std.item()
                     epoch_loss_std += loss_std_item
 
-                # JEPA Training
-                current_loss_jepa_pred_item = 0 # for logging
-                current_loss_jepa_aux_item = 0 # for logging
-                current_total_loss_jepa_item = 0 # for logging
+                current_loss_jepa_pred_item = 0
+                current_loss_jepa_aux_item = 0
+                current_total_loss_jepa_item = 0
                 if jepa_model and not early_stop_jepa:
                     optimizer_jepa.zero_grad()
                     pred_emb, target_emb_detached, online_s_t_emb, online_s_t_plus_1_emb = jepa_model(s_t, a_t_processed, s_t_plus_1)
@@ -116,40 +136,36 @@ def run_training_epochs(
                     if aux_loss_fn is not None and aux_loss_weight > 0:
                         aux_term_s_t, _, _ = aux_loss_fn.calculate_reg_terms(online_s_t_emb)
                         aux_term_s_t_plus_1, _, _ = aux_loss_fn.calculate_reg_terms(online_s_t_plus_1_emb)
-                        current_loss_jepa_aux = (aux_term_s_t + aux_term_s_t_plus_1) * 0.5
+                        current_loss_jepa_aux = (aux_term_s_t + aux_term_s_t_plus_1_val) * 0.5 # Typo fixed: aux_term_s_t_plus_1_val -> aux_term_s_t_plus_1
 
-                    current_loss_jepa_aux_item = current_loss_jepa_aux.item() # raw aux loss
+                    current_loss_jepa_aux_item = current_loss_jepa_aux.item()
                     total_loss_jepa = loss_jepa_pred + current_loss_jepa_aux * aux_loss_weight
                     current_total_loss_jepa_item = total_loss_jepa.item()
                     total_loss_jepa.backward()
                     optimizer_jepa.step()
-                    jepa_model.update_target_network() # EMA update for target encoder
+                    jepa_model.update_target_network()
                     epoch_loss_jepa_pred += current_loss_jepa_pred_item
                     epoch_loss_jepa_aux += current_loss_jepa_aux_item
 
-
                 if (batch_idx + 1) % log_interval == 0:
                     log_msg = f"  Epoch {epoch+1}, Batch {batch_idx+1}/{num_train_batches}:"
-                    if std_enc_dec and not early_stop_enc_dec:
-                        log_msg += f" StdEncDec L: {loss_std_item:.4f} |"
+                    if std_enc_dec and not early_stop_enc_dec: log_msg += f" StdEncDec L: {loss_std_item:.4f} |"
                     if jepa_model and not early_stop_jepa:
                         weighted_aux_loss_str = f"{(current_loss_jepa_aux_item * aux_loss_weight):.4f}" if aux_loss_fn and aux_loss_weight > 0 else "N/A"
                         log_msg += (f" JEPA Pred L: {current_loss_jepa_pred_item:.4f},"
                                     f" {aux_loss_name} AuxRawL: {current_loss_jepa_aux_item:.4f} (W: {weighted_aux_loss_str}),"
                                     f" Total JEPA L: {current_total_loss_jepa_item:.4f}")
-                    if log_msg[-1] != ':': print(log_msg) # Avoid printing if no models trained in batch
+                    if log_msg[-1] != ':': print(log_msg)
 
         # === Validation Phase ===
-        # Run validation if val_dataloader exists and at least one model is not early_stopped
-        if val_dataloader and ( (std_enc_dec and not early_stop_enc_dec) or (jepa_model and not early_stop_jepa) ):
+        if val_dataloader and ((std_enc_dec and not early_stop_enc_dec) or (jepa_model and not early_stop_jepa)):
             if std_enc_dec: std_enc_dec.eval()
             if jepa_model: jepa_model.eval()
-            if aux_loss_fn and hasattr(aux_loss_fn, 'eval'): # For DINO Loss
-                aux_loss_fn.eval()
+            if aux_loss_fn and hasattr(aux_loss_fn, 'eval'): aux_loss_fn.eval()
 
             epoch_val_loss_std = 0
             epoch_val_loss_jepa_pred = 0
-            epoch_val_loss_jepa_aux = 0 # Raw
+            epoch_val_loss_jepa_aux = 0
 
             with torch.no_grad():
                 for s_t_val, a_t_val, r_t_val, s_t_plus_1_val in val_dataloader:
@@ -168,14 +184,13 @@ def run_training_epochs(
                     if jepa_model and not early_stop_jepa:
                         pred_emb_val, target_emb_detached_val, online_s_t_emb_val, online_s_t_plus_1_emb_val = jepa_model(s_t_val, a_t_val_processed, s_t_plus_1_val)
                         val_loss_jepa_pred = mse_loss_fn(pred_emb_val, target_emb_detached_val)
-
                         current_val_loss_jepa_aux = torch.tensor(0.0, device=device)
                         if aux_loss_fn is not None and aux_loss_weight > 0:
                             aux_term_s_t_val, _, _ = aux_loss_fn.calculate_reg_terms(online_s_t_emb_val)
                             aux_term_s_t_plus_1_val, _, _ = aux_loss_fn.calculate_reg_terms(online_s_t_plus_1_emb_val)
                             current_val_loss_jepa_aux = (aux_term_s_t_val + aux_term_s_t_plus_1_val) * 0.5
                         epoch_val_loss_jepa_pred += val_loss_jepa_pred.item()
-                        epoch_val_loss_jepa_aux += current_val_loss_jepa_aux.item() # raw aux loss
+                        epoch_val_loss_jepa_aux += current_val_loss_jepa_aux.item()
 
             num_val_batches = len(val_dataloader)
             avg_val_loss_std = epoch_val_loss_std / num_val_batches if num_val_batches > 0 and std_enc_dec and not early_stop_enc_dec else float('inf')
@@ -186,123 +201,225 @@ def run_training_epochs(
             print(f"--- Epoch {epoch+1} Validation Summary ---")
             if std_enc_dec and not early_stop_enc_dec:
                 print(f"  Avg Val StdEncDec L: {avg_val_loss_std:.4f}")
-            if jepa_model and not early_stop_jepa:
-                print(f"  Avg Val JEPA Pred L: {avg_val_loss_jepa_pred:.4f}, {aux_loss_name} AuxRawL: {avg_val_loss_jepa_aux_raw:.4f}, Total Val JEPA L: {avg_total_val_loss_jepa:.4f}")
-
-            if std_enc_dec and not early_stop_enc_dec:
                 if avg_val_loss_std < best_val_loss_enc_dec - delta:
                     best_val_loss_enc_dec = avg_val_loss_std
-                    if checkpoint_path_enc_dec:
-                        os.makedirs(model_dir, exist_ok=True) # Ensure model_dir exists
-                        torch.save(std_enc_dec.state_dict(), checkpoint_path_enc_dec)
-                    epochs_no_improve_enc_dec = 0
-                    print(f"  Encoder/Decoder: Val loss improved. Saved model to {checkpoint_path_enc_dec}")
+                    if checkpoint_path_enc_dec: os.makedirs(model_dir, exist_ok=True); torch.save(std_enc_dec.state_dict(), checkpoint_path_enc_dec)
+                    epochs_no_improve_enc_dec = 0; print(f"  Encoder/Decoder: Val loss improved. Saved model to {checkpoint_path_enc_dec}")
                 else:
-                    epochs_no_improve_enc_dec += 1
-                    print(f"  Encoder/Decoder: No val improvement for {epochs_no_improve_enc_dec} epochs.")
-                    if epochs_no_improve_enc_dec >= patience:
-                        early_stop_enc_dec = True
-                        print("  Encoder/Decoder: Early stopping triggered.")
+                    epochs_no_improve_enc_dec += 1; print(f"  Encoder/Decoder: No val improvement for {epochs_no_improve_enc_dec} epochs.")
+                    if epochs_no_improve_enc_dec >= patience: early_stop_enc_dec = True; print("  Encoder/Decoder: Early stopping triggered.")
 
             if jepa_model and not early_stop_jepa:
+                print(f"  Avg Val JEPA Pred L: {avg_val_loss_jepa_pred:.4f}, {aux_loss_name} AuxRawL: {avg_val_loss_jepa_aux_raw:.4f}, Total Val JEPA L: {avg_total_val_loss_jepa:.4f}")
                 if avg_total_val_loss_jepa < best_val_loss_jepa - delta:
                     best_val_loss_jepa = avg_total_val_loss_jepa
-                    if checkpoint_path_jepa:
-                        os.makedirs(model_dir, exist_ok=True) # Ensure model_dir exists
-                        torch.save(jepa_model.state_dict(), checkpoint_path_jepa)
-                    epochs_no_improve_jepa = 0
-                    print(f"  JEPA: Val loss improved. Saved model to {checkpoint_path_jepa}")
+                    if checkpoint_path_jepa: os.makedirs(model_dir, exist_ok=True); torch.save(jepa_model.state_dict(), checkpoint_path_jepa)
+                    epochs_no_improve_jepa = 0; print(f"  JEPA: Val loss improved. Saved model to {checkpoint_path_jepa}")
                 else:
-                    epochs_no_improve_jepa += 1
-                    print(f"  JEPA: No val improvement for {epochs_no_improve_jepa} epochs.")
-                    if epochs_no_improve_jepa >= patience:
-                        early_stop_jepa = True
-                        print("  JEPA: Early stopping triggered.")
+                    epochs_no_improve_jepa += 1; print(f"  JEPA: No val improvement for {epochs_no_improve_jepa} epochs.")
+                    if epochs_no_improve_jepa >= patience: early_stop_jepa = True; print("  JEPA: Early stopping triggered.")
 
         # --- Reward MLP Training Loop ---
-        num_batches_reward_train = 0 # Reset per epoch
-        # Check if any reward MLP needs training
-        reward_enc_dec_train_needed = reward_mlp_enc_dec and enc_dec_mlp_config.get('enabled', False) and not early_stop_enc_dec and optimizer_reward_mlp_enc_dec and std_enc_dec
-        reward_jepa_train_needed = reward_mlp_jepa and jepa_mlp_config.get('enabled', False) and not early_stop_jepa and optimizer_reward_mlp_jepa and jepa_model
+        # (Assuming this part remains largely unchanged, but ensure it respects early_stop_enc_dec and early_stop_jepa for its inputs)
+        num_batches_reward_train = 0
+        reward_enc_dec_train_needed = reward_mlp_enc_dec and enc_dec_mlp_config.get('enabled', False) and optimizer_reward_mlp_enc_dec and std_enc_dec # No longer tied to early_stop_enc_dec directly for the MLP itself
+        reward_jepa_train_needed = reward_mlp_jepa and jepa_mlp_config.get('enabled', False) and optimizer_reward_mlp_jepa and jepa_model # No longer tied to early_stop_jepa directly
 
         if train_dataloader and (reward_enc_dec_train_needed or reward_jepa_train_needed):
-            print(f"Epoch {epoch+1} - Starting Reward MLP Training...")
-            if std_enc_dec: std_enc_dec.eval() # Main models providing input to MLPs should be in eval
+            if std_enc_dec: std_enc_dec.eval()
             if jepa_model: jepa_model.eval()
             if reward_mlp_enc_dec and reward_enc_dec_train_needed: reward_mlp_enc_dec.train()
             if reward_mlp_jepa and reward_jepa_train_needed: reward_mlp_jepa.train()
 
+            current_epoch_loss_reward_enc_dec = 0 # Track per epoch for avg
+            current_epoch_loss_reward_jepa = 0    # Track per epoch for avg
+
             for reward_batch_idx, (s_t_reward, a_t_reward, r_t_reward, s_t_plus_1_reward) in enumerate(train_dataloader):
                 s_t_reward, r_t_reward, s_t_plus_1_reward = s_t_reward.to(device), r_t_reward.to(device).float().unsqueeze(1), s_t_plus_1_reward.to(device)
                 if action_type == 'discrete':
-                    if a_t_reward.ndim == 1: a_t_reward = a_t_reward.unsqueeze(1)
                     a_t_reward_processed = F.one_hot(a_t_reward.long().view(-1), num_classes=action_dim).float().to(device)
                 else:
                     a_t_reward_processed = a_t_reward.float().to(device)
-
                 num_batches_reward_train +=1
 
                 if reward_enc_dec_train_needed:
                     optimizer_reward_mlp_enc_dec.zero_grad()
                     with torch.no_grad():
-                        # Input for this MLP: predicted next state from std_enc_dec
                         predicted_s_t_plus_1_for_reward = std_enc_dec(s_t_reward, a_t_reward_processed).detach()
-
-                    if enc_dec_mlp_config.get('input_type') == "flatten": # As per original config
-                        input_enc_dec_reward_mlp = predicted_s_t_plus_1_for_reward.view(predicted_s_t_plus_1_for_reward.size(0), -1)
-                    else: # Fallback, or could be error
-                        input_enc_dec_reward_mlp = predicted_s_t_plus_1_for_reward.view(predicted_s_t_plus_1_for_reward.size(0), -1)
-
+                    input_enc_dec_reward_mlp = predicted_s_t_plus_1_for_reward.view(predicted_s_t_plus_1_for_reward.size(0), -1)
                     pred_reward_enc_dec = reward_mlp_enc_dec(input_enc_dec_reward_mlp)
                     loss_reward_enc_dec = mse_loss_fn(pred_reward_enc_dec, r_t_reward)
-                    loss_reward_enc_dec.backward()
-                    optimizer_reward_mlp_enc_dec.step()
-                    epoch_loss_reward_enc_dec += loss_reward_enc_dec.item()
+                    loss_reward_enc_dec.backward(); optimizer_reward_mlp_enc_dec.step()
+                    current_epoch_loss_reward_enc_dec += loss_reward_enc_dec.item()
                     if (reward_batch_idx + 1) % enc_dec_mlp_config.get('log_interval', log_interval) == 0:
                         print(f"  Epoch {epoch+1}, Reward MLP (Enc-Dec) Batch {reward_batch_idx+1}/{num_train_batches}: Loss {loss_reward_enc_dec.item():.4f}")
 
                 if reward_jepa_train_needed:
                     optimizer_reward_mlp_jepa.zero_grad()
                     with torch.no_grad():
-                        # Input for this MLP: JEPA's predicted embedding of next state
                         pred_emb_for_reward, _, _, _ = jepa_model(s_t_reward, a_t_reward_processed, s_t_plus_1_reward)
                         input_jepa_reward_mlp = pred_emb_for_reward.detach()
-
                     pred_reward_jepa = reward_mlp_jepa(input_jepa_reward_mlp)
                     loss_reward_jepa = mse_loss_fn(pred_reward_jepa, r_t_reward)
-                    loss_reward_jepa.backward()
-                    optimizer_reward_mlp_jepa.step()
-                    epoch_loss_reward_jepa += loss_reward_jepa.item()
+                    loss_reward_jepa.backward(); optimizer_reward_mlp_jepa.step()
+                    current_epoch_loss_reward_jepa += loss_reward_jepa.item()
                     if (reward_batch_idx + 1) % jepa_mlp_config.get('log_interval', log_interval) == 0:
                          print(f"  Epoch {epoch+1}, Reward MLP (JEPA) Batch {reward_batch_idx+1}/{num_train_batches}: Loss {loss_reward_jepa.item():.4f}")
+            epoch_loss_reward_enc_dec = current_epoch_loss_reward_enc_dec # Store total for epoch avg
+            epoch_loss_reward_jepa = current_epoch_loss_reward_jepa       # Store total for epoch avg
+
 
         # --- Epoch Summary ---
-        avg_loss_std = epoch_loss_std / num_train_batches if std_enc_dec and not early_stop_enc_dec and num_train_batches > 0 else 0
-        avg_loss_jepa_pred = epoch_loss_jepa_pred / num_train_batches if jepa_model and not early_stop_jepa and num_train_batches > 0 else 0
-        avg_loss_jepa_aux_raw = epoch_loss_jepa_aux / num_train_batches if jepa_model and not early_stop_jepa and num_train_batches > 0 else 0
-
-        avg_loss_reward_enc_dec = epoch_loss_reward_enc_dec / num_batches_reward_train if num_batches_reward_train > 0 and reward_enc_dec_train_needed else 0
-        avg_loss_reward_jepa = epoch_loss_reward_jepa / num_batches_reward_train if num_batches_reward_train > 0 and reward_jepa_train_needed else 0
-
         print(f"--- Epoch {epoch+1}/{num_epochs} Training Summary ---")
-        if std_enc_dec and not early_stop_enc_dec: print(f"  Avg Train StdEncDec L: {avg_loss_std:.4f}")
+        if std_enc_dec and not early_stop_enc_dec: print(f"  Avg Train StdEncDec L: {(epoch_loss_std / num_train_batches if num_train_batches > 0 else 0):.4f}")
         if jepa_model and not early_stop_jepa:
-            avg_total_jepa_loss = avg_loss_jepa_pred + avg_loss_jepa_aux_raw * aux_loss_weight
-            print(f"  Avg Train JEPA Pred L: {avg_loss_jepa_pred:.4f}, {aux_loss_name} AuxRawL: {avg_loss_jepa_aux_raw:.4f}, Total Train JEPA L: {avg_total_jepa_loss:.4f}")
-        if reward_enc_dec_train_needed: # Check if it was supposed to run
-            print(f"  Avg Train Reward MLP (Enc-Dec) L: {avg_loss_reward_enc_dec:.4f}")
-        if reward_jepa_train_needed: # Check if it was supposed to run
-            print(f"  Avg Train Reward MLP (JEPA) L: {avg_loss_reward_jepa:.4f}")
+            avg_total_jepa_loss = (epoch_loss_jepa_pred / num_train_batches if num_train_batches > 0 else 0) + \
+                                  (epoch_loss_jepa_aux / num_train_batches if num_train_batches > 0 else 0) * aux_loss_weight
+            print(f"  Avg Train JEPA Pred L: {(epoch_loss_jepa_pred / num_train_batches if num_train_batches > 0 else 0):.4f}, "
+                  f"{aux_loss_name} AuxRawL: {(epoch_loss_jepa_aux / num_train_batches if num_train_batches > 0 else 0):.4f}, "
+                  f"Total Train JEPA L: {avg_total_jepa_loss:.4f}")
+        if reward_enc_dec_train_needed: print(f"  Avg Train Reward MLP (Enc-Dec) L: {(epoch_loss_reward_enc_dec / num_batches_reward_train if num_batches_reward_train > 0 else 0):.4f}")
+        if reward_jepa_train_needed: print(f"  Avg Train Reward MLP (JEPA) L: {(epoch_loss_reward_jepa / num_batches_reward_train if num_batches_reward_train > 0 else 0):.4f}")
 
         if early_stop_enc_dec and early_stop_jepa:
-            print("Both models triggered early stopping or were not set to train. Ending training.")
-            break
+            print("Both main models (StdEncDec, JEPA) triggered early stopping or were skipped. Checking JEPA Decoder training next.")
+            break # Break from main model epoch loop
 
-    print("Main training loop finished from training_engine.")
-    # Return paths to best models for main script to load if needed.
-    # Or could return the models themselves if they were modified in place (e.g. loaded best weights)
-    # For now, just indicate completion. Main script will handle loading from fixed paths.
+    print("Main models training loop finished.")
+
+    # --- JEPA State Decoder Training Loop ---
+    checkpoint_path_jepa_decoder = None # Initialize for return value
+    jepa_decoder_training_config = config.get('jepa_decoder_training', {})
+
+    if jepa_decoder and optimizer_jepa_decoder and jepa_decoder_training_config.get('enabled', False):
+        print("\nStarting JEPA State Decoder training...")
+
+        jepa_decoder_early_stop_config = jepa_decoder_training_config.get('early_stopping', {})
+        patience_decoder = jepa_decoder_early_stop_config.get('patience', 10)
+        delta_decoder = jepa_decoder_early_stop_config.get('delta', 0.001)
+        # Ensure model_dir is used for decoder checkpoint path
+        decoder_cp_name = jepa_decoder_training_config.get('checkpoint_path', 'best_jepa_decoder.pth')
+        checkpoint_path_jepa_decoder = os.path.join(model_dir, decoder_cp_name)
+
+        best_val_loss_jepa_decoder = float('inf')
+        epochs_no_improve_jepa_decoder = 0
+        early_stop_jepa_decoder = False
+
+        num_epochs_decoder = jepa_decoder_training_config.get('num_epochs', 50)
+        decoder_log_interval = jepa_decoder_training_config.get('log_interval', log_interval) # Use its own or general log_interval
+
+        for decoder_epoch in range(num_epochs_decoder):
+            if jepa_model: jepa_model.eval() # JEPA model (encoder part) should be in eval mode
+            jepa_decoder.train()
+            epoch_loss_jepa_decoder_train = 0
+            num_batches_jepa_decoder_train = len(train_dataloader) if train_dataloader else 0
+
+            if num_batches_jepa_decoder_train == 0:
+                print(f"JEPA Decoder Epoch {decoder_epoch+1} has no training data. Skipping training phase.")
+                # If no training data, validation might still run if it was the plan.
+            else:
+                for batch_idx, (s_t, a_t, _, s_t_plus_1) in enumerate(train_dataloader):
+                    s_t, s_t_plus_1 = s_t.to(device), s_t_plus_1.to(device)
+                    if action_type == 'discrete':
+                        if a_t.ndim == 1: a_t = a_t.unsqueeze(1)
+                        a_t_processed = F.one_hot(a_t.long().view(-1), num_classes=action_dim).float().to(device)
+                    else:
+                        a_t_processed = a_t.float().to(device)
+
+                    optimizer_jepa_decoder.zero_grad()
+
+                    with torch.no_grad(): # JEPA model provides predictor embedding
+                        if not jepa_model: # Should not happen if decoder is enabled and needs jepa
+                            print("Error: JEPA model is None, cannot get predictor embedding for JEPA decoder.")
+                            early_stop_jepa_decoder = True; break
+                        pred_emb, _, _, _ = jepa_model(s_t, a_t_processed, s_t_plus_1)
+
+                    jepa_predictor_output = pred_emb.detach() # Detach before feeding to decoder
+                    reconstructed_s_t_plus_1 = jepa_decoder(jepa_predictor_output)
+
+                    loss_jepa_decoder = mse_loss_fn(reconstructed_s_t_plus_1, s_t_plus_1)
+                    loss_jepa_decoder.backward()
+                    optimizer_jepa_decoder.step()
+
+                    epoch_loss_jepa_decoder_train += loss_jepa_decoder.item()
+
+                    if (batch_idx + 1) % decoder_log_interval == 0:
+                        print(f"  JEPA Decoder Epoch {decoder_epoch+1}, Batch {batch_idx+1}/{num_batches_jepa_decoder_train}: Train Loss {loss_jepa_decoder.item():.4f}")
+                if early_stop_jepa_decoder: break # from inner batch loop if error occurred
+
+            avg_train_loss_jepa_decoder = epoch_loss_jepa_decoder_train / num_batches_jepa_decoder_train if num_batches_jepa_decoder_train > 0 else 0
+
+            # JEPA Decoder Validation Phase
+            if val_dataloader:
+                jepa_decoder.eval()
+                if jepa_model: jepa_model.eval() # Ensure JEPA (encoder) is also in eval for validation consistency
+
+                epoch_val_loss_jepa_decoder = 0
+                num_val_batches_decoder = len(val_dataloader)
+
+                with torch.no_grad():
+                    for s_t_val, a_t_val, _, s_t_plus_1_val in val_dataloader:
+                        s_t_val, s_t_plus_1_val = s_t_val.to(device), s_t_plus_1_val.to(device)
+                        if action_type == 'discrete':
+                            if a_t_val.ndim == 1: a_t_val = a_t_val.unsqueeze(1)
+                            a_t_val_processed = F.one_hot(a_t_val.long().view(-1), num_classes=action_dim).float().to(device)
+                        else:
+                            a_t_val_processed = a_t_val.float().to(device)
+
+                        if not jepa_model:
+                             print("Error: JEPA model is None during JEPA decoder validation.")
+                             early_stop_jepa_decoder = True; break
+                        pred_emb_val, _, _, _ = jepa_model(s_t_val, a_t_val_processed, s_t_plus_1_val)
+                        jepa_predictor_output_val = pred_emb_val.detach()
+
+                        reconstructed_s_t_plus_1_val = jepa_decoder(jepa_predictor_output_val)
+                        val_loss_dec = mse_loss_fn(reconstructed_s_t_plus_1_val, s_t_plus_1_val)
+                        epoch_val_loss_jepa_decoder += val_loss_dec.item()
+                if early_stop_jepa_decoder: break # from epoch loop if error in val
+
+                avg_val_loss_jepa_decoder = epoch_val_loss_jepa_decoder / num_val_batches_decoder if num_val_batches_decoder > 0 else float('inf')
+                print(f"--- JEPA Decoder Epoch {decoder_epoch+1} Validation Summary ---")
+                print(f"  Avg Val JEPA Decoder L: {avg_val_loss_jepa_decoder:.4f}")
+
+                if avg_val_loss_jepa_decoder < best_val_loss_jepa_decoder - delta_decoder:
+                    best_val_loss_jepa_decoder = avg_val_loss_jepa_decoder
+                    if checkpoint_path_jepa_decoder:
+                        os.makedirs(model_dir, exist_ok=True)
+                        torch.save(jepa_decoder.state_dict(), checkpoint_path_jepa_decoder)
+                    epochs_no_improve_jepa_decoder = 0
+                    print(f"  JEPA Decoder: Val loss improved. Saved model to {checkpoint_path_jepa_decoder}")
+                else:
+                    epochs_no_improve_jepa_decoder += 1
+                    print(f"  JEPA Decoder: No val improvement for {epochs_no_improve_jepa_decoder} epochs.")
+                    if epochs_no_improve_jepa_decoder >= patience_decoder:
+                        early_stop_jepa_decoder = True
+                        print("  JEPA Decoder: Early stopping triggered.")
+            else: # No validation dataloader
+                print(f"--- JEPA Decoder Epoch {decoder_epoch+1} Training Summary (No Validation) ---")
+                print(f"  Avg Train JEPA Decoder L: {avg_train_loss_jepa_decoder:.4f}")
+                if checkpoint_path_jepa_decoder: # Save last epoch if no validation
+                    os.makedirs(model_dir, exist_ok=True)
+                    torch.save(jepa_decoder.state_dict(), checkpoint_path_jepa_decoder)
+                    print(f"  JEPA Decoder: Saved model from last epoch to {checkpoint_path_jepa_decoder} (no validation set)")
+
+
+            if early_stop_jepa_decoder:
+                print(f"JEPA State Decoder early stopping at epoch {decoder_epoch+1}.")
+                break # Break from JEPA decoder epoch loop
+
+        print("JEPA State Decoder training finished.")
+        if checkpoint_path_jepa_decoder and os.path.exists(checkpoint_path_jepa_decoder):
+            print(f"Loading best JEPA State Decoder model from {checkpoint_path_jepa_decoder}")
+            jepa_decoder.load_state_dict(torch.load(checkpoint_path_jepa_decoder, map_location=device))
+    else:
+        if not jepa_decoder: print("JEPA State Decoder model not provided.")
+        elif not optimizer_jepa_decoder: print("Optimizer for JEPA State Decoder not provided.")
+        elif not jepa_decoder_training_config.get('enabled', False): print("JEPA State Decoder training is disabled in config.")
+
+
+    print("All training processes finished from training_engine.")
     return {
-        "best_checkpoint_enc_dec": checkpoint_path_enc_dec if os.path.exists(checkpoint_path_enc_dec) and std_enc_dec else None,
-        "best_checkpoint_jepa": checkpoint_path_jepa if os.path.exists(checkpoint_path_jepa) and jepa_model else None
+        "best_checkpoint_enc_dec": checkpoint_path_enc_dec if std_enc_dec and os.path.exists(checkpoint_path_enc_dec) else None,
+        "best_checkpoint_jepa": checkpoint_path_jepa if jepa_model and os.path.exists(checkpoint_path_jepa) else None,
+        "best_checkpoint_jepa_decoder": checkpoint_path_jepa_decoder if jepa_decoder and jepa_decoder_training_config.get('enabled', False) and checkpoint_path_jepa_decoder and os.path.exists(checkpoint_path_jepa_decoder) else None
     }


### PR DESCRIPTION
This commit introduces two main features:

1.  **JEPA State Decoder Training:**
    - Adds a new model `JEPAStateDecoder` that can be trained to predict the non-encoded next state (raw pixels) from the JEPA model's predictor representation.
    - This decoder is trained *after* the main JEPA training has concluded, using the frozen representations from the trained JEPA predictor.
    - Configuration for this decoder (enable, epochs, LR, checkpointing, early stopping) is added to `config.yaml` under `jepa_decoder_training`.
    - Model setup, optimizer setup, training engine, and main script have been updated to support this new training phase.

2.  **Skip Training if Model Loaded:**
    - Adds options to `config.yaml` under `training_options` to skip the training of the Standard Encoder/Decoder (`skip_std_enc_dec_training_if_loaded`) and/or the JEPA model (`skip_jepa_training_if_loaded`) if a pre-trained model is loaded via `load_model_path`.
    - `main.py` now detects if models were successfully loaded and passes this information to `training_engine.py`, which will bypass the respective training loops if the skip option is enabled.

These changes allow for more flexible experimentation, enabling you to train and evaluate different components of the system independently and to reuse pre-trained artifacts more effectively.