### PR TITLE
feat: Implement target encoder modes for JEPA model

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,6 +80,7 @@ decoder_patch_size: 8   # Patch size for reconstructing the output image by the 
 # JEPA Model
 jepa_predictor_hidden_dim: 256 # Hidden dimension for the JEPA predictor MLP
 ema_decay: 0.996              # EMA decay rate for updating the target encoder in JEPA
+target_encoder_mode: "default" # Options: "default", "vjepa2", "none"
 #vicreg_loss_weight: 1.0       # Weight for the VICReg loss component in JEPA's total loss
 # VICRegLoss coefficients (sim_coeff, std_coeff, cov_coeff) are currently set to defaults
 # within train.py when VICRegLoss is instantiated. To configure them from here,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -187,5 +187,182 @@ class TestModelSelection(unittest.TestCase):
         jepa_mlp(self.dummy_img, self.dummy_action, self.dummy_img)
 
 
+class TestJEPATargetEncoderModes(unittest.TestCase):
+    def setUp(self):
+        self.batch_size = 2
+        self.image_size = 32  # Smaller for faster tests
+        self.patch_size = 8
+        self.input_channels = 1 # Simpler
+        self.action_dim = 2
+        self.action_emb_dim = 4
+        self.latent_dim = 8 # Predictor output dim must match latent_dim
+        self.predictor_hidden_dim = 16
+        self.ema_decay = 0.5 # For easier testing of weight changes
+        self.encoder_type = 'cnn'
+        self.encoder_params = {
+            'num_conv_layers': 1,
+            'base_filters': 4,
+            'kernel_size': 3,
+            'stride': 1,
+            'padding': 1,
+            'fc_hidden_dim': None # Ensure direct output to latent_dim
+        }
+
+        self.s_t = torch.randn(self.batch_size, self.input_channels, self.image_size, self.image_size)
+        self.action = torch.randn(self.batch_size, self.action_dim)
+        self.s_t_plus_1 = torch.randn(self.batch_size, self.input_channels, self.image_size, self.image_size)
+
+    def _create_jepa_model(self, target_encoder_mode):
+        return JEPA(
+            image_size=self.image_size,
+            patch_size=self.patch_size,
+            input_channels=self.input_channels,
+            action_dim=self.action_dim,
+            action_emb_dim=self.action_emb_dim,
+            latent_dim=self.latent_dim,
+            predictor_hidden_dim=self.predictor_hidden_dim,
+            predictor_output_dim=self.latent_dim, # Must match latent_dim
+            ema_decay=self.ema_decay,
+            encoder_type=self.encoder_type,
+            encoder_params=self.encoder_params,
+            target_encoder_mode=target_encoder_mode
+        )
+
+    def _get_target_encoder_weights(self, model):
+        if model.target_encoder is not None:
+            return {k: v.clone() for k, v in model.target_encoder.state_dict().items()}
+        return None
+
+    def _check_weights_equal(self, weights1_dict, weights2_dict):
+        if weights1_dict is None and weights2_dict is None:
+            return True
+        if weights1_dict is None or weights2_dict is None:
+            return False
+        if len(weights1_dict) != len(weights2_dict):
+            return False
+        for key in weights1_dict:
+            if not torch.equal(weights1_dict[key], weights2_dict[key]):
+                return False
+        return True
+
+    def _perform_gradient_check(self, model, outputs, target_encoder_expected_grad=False):
+        # Dummy loss: sum of the first output tensor (predicted_s_t_plus_1_embedding)
+        loss = outputs[0].sum()
+        model.zero_grad() # Zero gradients before backward pass
+        loss.backward()
+
+        # Online encoder should always have gradients
+        for param in model.online_encoder.parameters():
+            self.assertIsNotNone(param.grad, "Online encoder should have gradients.")
+            self.assertTrue(param.grad.abs().sum() > 0, "Online encoder gradient sum should be > 0")
+
+
+        # Predictor should always have gradients
+        for param in model.predictor.parameters():
+            self.assertIsNotNone(param.grad, "Predictor should have gradients.")
+            self.assertTrue(param.grad.abs().sum() > 0, "Predictor gradient sum should be > 0")
+
+
+        # Target encoder (if exists) should not have gradients
+        if model.target_encoder is not None:
+            for param in model.target_encoder.parameters():
+                if target_encoder_expected_grad: # This case should ideally not happen for target encoder
+                     self.assertIsNotNone(param.grad, "Target encoder was expected to have grad but did not.")
+                else:
+                     self.assertIsNone(param.grad, "Target encoder should not have gradients.")
+        model.zero_grad() # Clean up gradients
+
+    def test_mode_default(self):
+        mode = "default"
+        model = self._create_jepa_model(mode)
+        self.assertIsNotNone(model.target_encoder, f"Target encoder should exist for mode '{mode}'")
+
+        # Check requires_grad
+        for param in model.online_encoder.parameters(): self.assertTrue(param.requires_grad)
+        for param in model.predictor.parameters(): self.assertTrue(param.requires_grad)
+        for param in model.target_encoder.parameters(): self.assertFalse(param.requires_grad)
+
+        initial_target_weights = self._get_target_encoder_weights(model)
+
+        outputs = model(self.s_t, self.action, self.s_t_plus_1)
+        pred_emb, target_emb_detached, online_s_t_emb, online_s_t_plus_1_emb = outputs
+
+        self.assertEqual(pred_emb.shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(target_emb_detached.shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(online_s_t_emb.shape, (self.batch_size, self.latent_dim))
+        self.assertIsNotNone(online_s_t_plus_1_emb, f"online_s_t_plus_1_emb should not be None for mode '{mode}'")
+        self.assertEqual(online_s_t_plus_1_emb.shape, (self.batch_size, self.latent_dim))
+
+        # Target weights should not change during forward for 'default'
+        current_target_weights_after_fwd = self._get_target_encoder_weights(model)
+        self.assertTrue(self._check_weights_equal(initial_target_weights, current_target_weights_after_fwd),
+                        "Target encoder weights should not change during forward pass for mode 'default'.")
+
+        model.perform_ema_update()
+        current_target_weights_after_ema = self._get_target_encoder_weights(model)
+        self.assertFalse(self._check_weights_equal(initial_target_weights, current_target_weights_after_ema),
+                         "Target encoder weights should change after perform_ema_update for mode 'default'.")
+
+        self._perform_gradient_check(model, outputs)
+
+
+    def test_mode_vjepa2(self):
+        mode = "vjepa2"
+        model = self._create_jepa_model(mode)
+        self.assertIsNotNone(model.target_encoder, f"Target encoder should exist for mode '{mode}'")
+
+        # Check requires_grad
+        for param in model.online_encoder.parameters(): self.assertTrue(param.requires_grad)
+        for param in model.predictor.parameters(): self.assertTrue(param.requires_grad)
+        for param in model.target_encoder.parameters(): self.assertFalse(param.requires_grad)
+
+        initial_target_weights = self._get_target_encoder_weights(model)
+
+        outputs = model(self.s_t, self.action, self.s_t_plus_1)
+        pred_emb, target_emb_detached, online_s_t_emb, online_s_t_plus_1_emb = outputs
+
+        self.assertEqual(pred_emb.shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(target_emb_detached.shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(online_s_t_emb.shape, (self.batch_size, self.latent_dim))
+        self.assertIsNone(online_s_t_plus_1_emb, f"online_s_t_plus_1_emb should be None for mode '{mode}'")
+
+        current_target_weights_after_fwd = self._get_target_encoder_weights(model)
+        self.assertFalse(self._check_weights_equal(initial_target_weights, current_target_weights_after_fwd),
+                         "Target encoder weights should change during forward pass for mode 'vjepa2'.")
+
+        # perform_ema_update should do nothing for vjepa2
+        model.perform_ema_update()
+        current_target_weights_after_ema_call = self._get_target_encoder_weights(model)
+        self.assertTrue(self._check_weights_equal(current_target_weights_after_fwd, current_target_weights_after_ema_call),
+                        "Target encoder weights should NOT change after perform_ema_update for mode 'vjepa2'.")
+
+        self._perform_gradient_check(model, outputs)
+
+    def test_mode_none(self):
+        mode = "none"
+        model = self._create_jepa_model(mode)
+        self.assertIsNone(model.target_encoder, f"Target encoder should be None for mode '{mode}'")
+
+        # Check requires_grad
+        for param in model.online_encoder.parameters(): self.assertTrue(param.requires_grad)
+        for param in model.predictor.parameters(): self.assertTrue(param.requires_grad)
+
+        outputs = model(self.s_t, self.action, self.s_t_plus_1)
+        pred_emb, target_emb_detached, online_s_t_emb, online_s_t_plus_1_emb = outputs
+
+        self.assertEqual(pred_emb.shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(target_emb_detached.shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(online_s_t_emb.shape, (self.batch_size, self.latent_dim))
+        self.assertIsNotNone(online_s_t_plus_1_emb, f"online_s_t_plus_1_emb should not be None for mode '{mode}'")
+        self.assertEqual(online_s_t_plus_1_emb.shape, (self.batch_size, self.latent_dim))
+
+        # perform_ema_update should do nothing (no target encoder)
+        model.perform_ema_update()
+        # No specific weight check needed as target_encoder is None.
+        # Just ensure no error occurs.
+
+        self._perform_gradient_check(model, outputs)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces a `target_encoder_mode` parameter for the JEPA model, allowing for different configurations of the target encoder usage.

The following modes are available:
- "default": The original behavior, where the target encoder is used for both s_t and s_t_plus_1 representations for the predictor. EMA updates are performed externally. Auxiliary loss uses online encodings of s_t and s_t_plus_1.
- "vjepa2": Inspired by V-JEPA 2. The online encoder processes s_t. The target encoder is updated with EMA *internally during the forward pass*. The target encoder then processes s_t_plus_1 (with stop_grad). The predictor uses online_encoder(s_t) to predict target_encoder(s_t_plus_1). Auxiliary loss is calculated only on online_encoder(s_t).
- "none": No target encoder is used. The online encoder is used for all representations. The predictor uses online_encoder(s_t) to predict online_encoder(s_t_plus_1) (with stop_grad on target). No EMA occurs.

Changes include:
- Added `target_encoder_mode` to `config.yaml`.
- Modified `src/models/jepa.py` to implement the three modes, including internal EMA updates for "vjepa2".
- Updated `src/training_engine.py` to correctly handle the EMA update trigger and to adjust auxiliary loss calculation based on the mode (specifically for "vjepa2" where only s_t's online encoding is used).
- Updated `docs/04_jepa_model.md` with detailed explanations of the new parameter and its modes.
- Added comprehensive unit tests in `tests/test_models.py` to verify the behavior of each mode, including output shapes, EMA updates, and gradient flow.