### PR TITLE
feat: Implement state-of-the-art weight initialization

### DIFF
--- a/src/models/cnn.py
+++ b/src/models/cnn.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from src.utils.weight_init import initialize_weights
 
 
 class CNNEncoder(nn.Module):
@@ -81,6 +82,8 @@ class CNNEncoder(nn.Module):
             )
         else:
             self.fc_net = nn.Linear(self.flattened_size, latent_dim)
+
+        self.apply(initialize_weights)
 
     def forward(self, img):
         # img: (batch, channels, height, width)

--- a/src/models/encoder_decoder.py
+++ b/src/models/encoder_decoder.py
@@ -7,6 +7,7 @@ from einops.layers.torch import Rearrange  # For use in __init__ as a layer
 from .vit import ViT
 from .cnn import CNNEncoder
 from .mlp import MLPEncoder
+from src.utils.weight_init import initialize_weights
 
 
 class StandardEncoderDecoder(nn.Module):
@@ -132,6 +133,7 @@ class StandardEncoderDecoder(nn.Module):
             ph=self.output_num_patches_h, pw=self.output_num_patches_w,
             c=self.output_channels
         )
+        self.apply(initialize_weights)
 
     def forward(self, current_state_img, action):
         # current_state_img: (b, c, h, w)

--- a/src/models/jepa.py
+++ b/src/models/jepa.py
@@ -6,6 +6,7 @@ import copy  # For deepcopying encoder for target network
 from .vit import ViT
 from .cnn import CNNEncoder
 from .mlp import MLPEncoder
+from src.utils.weight_init import initialize_weights
 
 
 class JEPA(nn.Module):
@@ -106,6 +107,8 @@ class JEPA(nn.Module):
 
         assert predictor_output_dim == latent_dim, \
             "Predictor output dimension must match encoder latent dimension for JEPA loss."
+
+        self.apply(initialize_weights)
 
     def _create_target_encoder(self):
         return copy.deepcopy(self.online_encoder)

--- a/src/models/jepa_state_decoder.py
+++ b/src/models/jepa_state_decoder.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 from einops.layers.torch import Rearrange
+from src.utils.weight_init import initialize_weights
 
 class JEPAStateDecoder(nn.Module):
     def __init__(self,
@@ -45,7 +46,7 @@ class JEPAStateDecoder(nn.Module):
         )
 
         # Learnable query tokens for the decoder (one set of queries for all patches)
-        self.decoder_query_tokens = nn.Parameter(torch.randn(1, self.num_output_patches, decoder_dim))
+        self.decoder_query_tokens = nn.Parameter(torch.randn(1, self.num_output_patches, decoder_dim) * 0.02)
 
         # Map decoder output to pixel values for each patch
         self.to_pixels = nn.Linear(decoder_dim, output_patch_dim)
@@ -57,6 +58,7 @@ class JEPAStateDecoder(nn.Module):
             h=self.output_num_patches_h, w=self.output_num_patches_w,
             c=output_channels
         )
+        self.apply(initialize_weights)
 
     def forward(self, jepa_predictor_embedding: torch.Tensor) -> torch.Tensor:
         """

--- a/src/models/mlp.py
+++ b/src/models/mlp.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from src.utils.weight_init import initialize_weights
 
 
 class MLPEncoder(nn.Module):
@@ -59,6 +60,7 @@ class MLPEncoder(nn.Module):
             layers.append(nn.Linear(input_dim, latent_dim))
 
         self.mlp_net = nn.Sequential(*layers)
+        self.apply(initialize_weights)
 
     def forward(self, img):
         # img: (batch, channels, height, width)
@@ -153,6 +155,7 @@ class RewardPredictorMLP(nn.Module):
 
         # Output a single scalar reward
         self.layers.append(nn.Linear(current_dim, 1))
+        self.apply(initialize_weights)
 
     def forward(self, x):
         # x: (batch_size, input_dim)

--- a/src/models/vit.py
+++ b/src/models/vit.py
@@ -1,6 +1,7 @@
 from einops import repeat
 import torch
 import torch.nn as nn
+from src.utils.weight_init import initialize_weights
 from einops import rearrange
 from einops.layers.torch import Rearrange
 
@@ -107,8 +108,8 @@ class ViT(nn.Module):
             nn.Linear(patch_dim, dim),
         )
 
-        self.pos_embedding = nn.Parameter(torch.randn(1, num_patches + 1, dim))
-        self.cls_token = nn.Parameter(torch.randn(1, 1, dim))
+        self.pos_embedding = nn.Parameter(torch.randn(1, num_patches + 1, dim) * 0.02)
+        self.cls_token = nn.Parameter(torch.randn(1, 1, dim) * 0.02)
         self.dropout = nn.Dropout(emb_dropout)
 
         self.transformer = Transformer(
@@ -127,6 +128,8 @@ class ViT(nn.Module):
             nn.LayerNorm(dim),
             nn.Linear(dim, num_classes)
         ) if num_classes > 0 else nn.Identity()  # Only add mlp_head if num_classes is positive
+
+        self.apply(initialize_weights)
 
     def forward(self, img):
         x = self.to_patch_embedding(img)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,1 @@
-# This file intentionally left blank to make the 'utils' directory a Python package.
+from .weight_init import initialize_weights

--- a/src/utils/weight_init.py
+++ b/src/utils/weight_init.py
@@ -1,0 +1,46 @@
+import torch
+import torch.nn as nn
+import math
+
+def initialize_weights(module):
+    """
+    Initializes weights for layers in a PyTorch module.
+
+    Args:
+        module (nn.Module): The module whose layers will be initialized.
+    """
+    for m in module.modules():
+        if isinstance(m, nn.Conv2d):
+            # Kaiming Normal initialization for Conv2d layers
+            # Recommended for layers followed by ReLU or LeakyReLU activations
+            nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            if m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+        elif isinstance(m, nn.Linear):
+            # Kaiming Normal initialization for Linear layers
+            # Recommended for layers followed by ReLU or GELU activations
+            # For other activations like Tanh or Sigmoid, Xavier/Glorot might be preferred
+            # but most modern networks use ReLU/GELU.
+            nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            if m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+            # Example for Xavier/Glorot if needed for specific linear layers:
+            # if hasattr(m, 'activation') and m.activation == 'tanh':
+            #     nn.init.xavier_normal_(m.weight)
+            # else:
+            #     nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            # if m.bias is not None:
+            #     nn.init.constant_(m.bias, 0)
+
+        elif isinstance(m, nn.Embedding):
+            # Initialize embedding layers with a normal distribution (small std dev)
+            nn.init.normal_(m.weight, mean=0, std=0.02)
+        elif isinstance(m, nn.LayerNorm):
+            # Initialize LayerNorm weights to 1 and biases to 0
+            # This is a common practice for LayerNorm initialization
+            if m.elementwise_affine: # LayerNorm has learnable affine parameters
+                nn.init.constant_(m.weight, 1.0)
+                nn.init.constant_(m.bias, 0.0)
+        # Note: For nn.Parameter tensors that are not part of a standard layer (e.g., ViT's cls_token, pos_embedding),
+        # they need to be initialized manually in their respective module's __init__ method,
+        # as module.apply() or module.modules() won't directly process them in the same way as nn.Module instances.


### PR DESCRIPTION
This commit introduces a standardized weight initialization strategy across all neural network models in the repository.

The following changes were made:
1.  I created a new utility function `initialize_weights` in `src/utils/weight_init.py`. This function applies:
    *   Kaiming Normal initialization for `nn.Linear` and `nn.Conv2d` layers (assuming ReLU/GELU activations).
    *   Normal initialization (mean=0, std=0.02) for `nn.Embedding` layers.
    *   Standard initialization (weights=1, bias=0) for `nn.LayerNorm` layers.
2.  I modified all model classes (`ViT`, `CNNEncoder`, `MLPEncoder`, `RewardPredictorMLP`, `JEPAStateDecoder`, `StandardEncoderDecoder`, `JEPA`) to use this utility via `self.apply(initialize_weights)`.
3.  I specifically adjusted the initialization for `nn.Parameter` based embeddings in `ViT` (`pos_embedding`, `cls_token`) and `JEPAStateDecoder` (`decoder_query_tokens`) to use a normal distribution with a standard deviation of 0.02.

These changes aim to improve training stability and potentially model performance by ensuring that all network weights are initialized according to established best practices.