### PR TITLE
feat: Enhance PPO data collection with reward logging and noise injec…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -174,4 +174,5 @@ ppo_agent:
   gamma: 0.99         # PPO gamma parameter (discount factor)
   gae_lambda: 0.95    # PPO gae_lambda parameter (factor for trade-off General Advantage Estimation)
   clip_range: 0.2     # PPO clip_range parameter (clipping parameter)
+  additional_log_std_noise: 0.0 # New parameter
   policy_type: "CnnPolicy" # Policy type, e.g., "CnnPolicy" for image-based envs


### PR DESCRIPTION
This commit introduces two main enhancements to the PPO data collection process:

1.  **Cumulative Reward Logging**: The `collect_ppo_episodes` function in `src/utils/data_utils.py` now prints the cumulative reward for each episode alongside the number of steps and transitions. This was already partially implemented, and this commit ensures it's correctly logged.

2.  **Policy Log_Std Adjustment**:
    - Added `additional_log_std_noise` parameter to `config.yaml` under the `ppo_agent` section. This parameter allows specifying a float value to be added to the PPO agent's policy `log_std` (or `action_dist.log_std_param` for certain policy types) after training.
    - Modified `src/utils/data_utils.py` in the `collect_ppo_episodes` function to read this configuration value and adjust the `ppo_agent.policy.log_std.data` (or equivalent) if the value is non-zero and the policy supports it. This is intended to increase randomness (exploration) during data collection if desired.

Unit tests for the `log_std` adjustment functionality have been added to `tests/test_data_utils.py`. These tests cover scenarios including noise addition to `log_std` and `action_dist.log_std_param`, no change for zero noise, and warnings for incompatible policy structures. Due to environment constraints preventing PyTorch installation, these tests were not executed during development but are included for future validation.