### PR TITLE
feat: Enhance JEPA decoder loss with differential MSE and detailed lo…

### DIFF
--- a/src/training_engine.py
+++ b/src/training_engine.py
@@ -100,9 +100,22 @@ def run_training_epochs(
         # Define metrics for JEPA_Decoder
         wandb_run.define_metric("JEPA_Decoder/train/step")      # Step for batch-wise train logs
         wandb_run.define_metric("JEPA_Decoder/epoch")           # Step for epoch-wise logs
-        wandb_run.define_metric("JEPA_Decoder/train/*", step_metric="JEPA_Decoder/train/step")
-        wandb_run.define_metric("JEPA_Decoder/val/*", step_metric="JEPA_Decoder/epoch")
-        wandb_run.define_metric("JEPA_Decoder/train_epoch_avg/*", step_metric="JEPA_Decoder/epoch")
+
+        # Train metrics (batch-wise)
+        wandb_run.define_metric("JEPA_Decoder/train/total_loss", step_metric="JEPA_Decoder/train/step")
+        wandb_run.define_metric("JEPA_Decoder/train/loss_mse_reconstruction", step_metric="JEPA_Decoder/train/step")
+        wandb_run.define_metric("JEPA_Decoder/train/loss_mse_diff", step_metric="JEPA_Decoder/train/step")
+        wandb_run.define_metric("JEPA_Decoder/train/Learning_Rate", step_metric="JEPA_Decoder/train/step") # Explicitly defined
+
+        # Validation metrics (epoch-wise)
+        wandb_run.define_metric("JEPA_Decoder/val/total_loss", step_metric="JEPA_Decoder/epoch")
+        wandb_run.define_metric("JEPA_Decoder/val/loss_mse_reconstruction", step_metric="JEPA_Decoder/epoch")
+        wandb_run.define_metric("JEPA_Decoder/val/loss_mse_diff", step_metric="JEPA_Decoder/epoch")
+
+        # Train epoch average metrics (epoch-wise)
+        wandb_run.define_metric("JEPA_Decoder/train_epoch_avg/total_loss", step_metric="JEPA_Decoder/epoch")
+        wandb_run.define_metric("JEPA_Decoder/train_epoch_avg/loss_mse_reconstruction", step_metric="JEPA_Decoder/epoch")
+        wandb_run.define_metric("JEPA_Decoder/train_epoch_avg/loss_mse_diff", step_metric="JEPA_Decoder/epoch")
 
     print(f"Starting training, main models for up to {num_epochs} epochs...")
 


### PR DESCRIPTION
This commit introduces the following changes to the JEPA decoder:

1.  **Modified Loss Function:** The decoder's loss function now includes an additional Mean Squared Error (MSE) term. This new term calculates the MSE specifically on the grid cells that differ between the input state `s_t` and the target state `s_t_plus_1`. The total loss is the sum of the original reconstruction MSE and this new differential MSE.

2.  **Updated Wandb Tracking:**
    - Wandb metric definitions in `src/training_engine.py` for `JEPA_Decoder` have been updated to be specific, replacing wildcard definitions.
    - New metrics are tracked: `loss_mse_reconstruction`, `loss_mse_diff`, and `total_loss` (renamed from `Loss` for clarity). These are logged for batch-wise training, epoch-average training, and epoch-wise validation scopes in `src/training_loops/jepa_decoder_loop.py`.

3.  **Enhanced Print Statements:** The epoch summary print statements in `src/training_loops/jepa_decoder_loop.py` now display a detailed breakdown of the average training and validation losses, including the total loss, reconstruction loss, and differential loss components.

These changes provide more insight into the decoder's learning process by distinguishing between general reconstruction capability and its ability to predict changes between states.